### PR TITLE
salt master and some infrastructure

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,30 +12,96 @@ settings = YAML.load_file local_config
 
 Vagrant.configure("2") do |config|
 
-  # Load Balancer Nodes
+  # Admin Nodes
   (1..1).each do |i|
-    hostname = "lb#{i}"
-    config.vm.define hostname do |proxy|
-      proxy.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
-      proxy.vm.box = "trusty64"
-      proxy.vm.hostname = hostname
-      proxy.vm.synced_folder "salt", "/srv/salt/"
+    hostname = "admin#{i}"
+    config.vm.define hostname do |admin|
+      admin.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+      admin.vm.box = "trusty64"
+      admin.vm.hostname = hostname
+      admin.vm.synced_folder "salt", "/srv/salt/"
+      admin.vm.network :private_network, ip: "#{settings['admin']['ip']}"
 
-
-      proxy.vm.network :private_network, ip: "#{settings['general']['network']}.100"
-      proxy.vm.network :forwarded_port, guest: 8080, host: settings['lb']['host_port']
-
-      proxy.vm.provider :virtualbox do |v|
+      admin.vm.provider :virtualbox do |v|
         v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
         v.customize ["modifyvm", :id, "--memory", 1024]
         v.customize ["modifyvm", :id, "--name", hostname]
       end
-      proxy.vm.provision :salt do |salt|
-        salt.masterless = true
-        salt.minion_config = "salt/minion/conf"
-        salt.grains_config = "salt/minion/grains/lb"
-        salt.run_highstate = true
-        salt.bootstrap_options = '-F -c /tmp/ -P'
+
+      admin.vm.provision :salt do |saltmaster|
+        saltmaster.always_install = true
+        saltmaster.install_master = true
+        saltmaster.master_config = "salt/master/conf"
+        saltmaster.masterless = false
+        saltmaster.bootstrap_options = '-F -c /tmp/ -P'
+      end
+
+      # http://foo-o-rama.com/vagrant--stdin-is-not-a-tty--fix.html
+      admin.vm.provision "fix-no-tty", type: "shell" do |s|
+          s.privileged = false
+          s.inline = "sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile"
+      end
+
+      admin.vm.provision "update system packages", type: "shell" do |s|
+        s.privileged = true
+        s.inline = "apt-get update && apt-get upgrade -Vy --force-yes"
+      end
+
+      admin.vm.provision "update hosts", type: "shell" do |s|
+        s.privileged = true
+        s.inline = "echo \"#{settings['admin']['ip']} salt\" >> /etc/hosts"
+      end
+
+      admin.vm.provision :salt do |saltminion|
+        saltminion.masterless = false
+        saltminion.minion_id = hostname
+        saltminion.minion_config = "salt/minion/conf"
+        saltminion.grains_config = "salt/minion/grains/admin"
+        saltminion.run_highstate = false
+        saltminion.bootstrap_options = '-F -c /tmp/ -P'
+      end
+    end
+  end
+
+  # Load Balancer Nodes
+  (1..1).each do |i|
+    hostname = "lb#{i}"
+    config.vm.define hostname do |lb|
+      lb.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+      lb.vm.box = "trusty64"
+      lb.vm.hostname = hostname
+      lb.vm.synced_folder "salt", "/srv/salt/"
+      lb.vm.network :private_network, ip: "#{settings['general']['network']}.8#{i}"
+
+      lb.vm.provider :virtualbox do |v|
+        v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+        v.customize ["modifyvm", :id, "--memory", 1024]
+        v.customize ["modifyvm", :id, "--name", hostname]
+      end
+
+      # http://foo-o-rama.com/vagrant--stdin-is-not-a-tty--fix.html
+      lb.vm.provision "fix-no-tty", type: "shell" do |s|
+          s.privileged = false
+          s.inline = "sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile"
+      end
+
+      lb.vm.provision "update system packages", type: "shell" do |s|
+        s.privileged = true
+        s.inline = "apt-get update && apt-get upgrade -Vy --force-yes"
+      end
+
+      lb.vm.provision "update hosts", type: "shell" do |s|
+        s.privileged = true
+        s.inline = "echo \"#{settings['admin']['ip']} salt\" >> /etc/hosts"
+      end
+
+      lb.vm.provision :salt do |saltminion|
+        saltminion.masterless = false
+        saltminion.minion_id = hostname
+        saltminion.minion_config = "salt/minion/conf"
+        saltminion.grains_config = "salt/minion/grains/lb"
+        saltminion.run_highstate = false
+        saltminion.bootstrap_options = '-F -c /tmp/ -P'
       end
     end
   end
@@ -48,12 +114,37 @@ Vagrant.configure("2") do |config|
       proxy.vm.box = "trusty64"
       proxy.vm.hostname = hostname
 
-      proxy.vm.network :private_network, ip: "10.0.0.100"
+      proxy.vm.network :private_network, ip: "#{settings['general']['network']}.10#{i}"
 
       proxy.vm.provider :virtualbox do |v|
         v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
         v.customize ["modifyvm", :id, "--memory", 1024]
         v.customize ["modifyvm", :id, "--name", hostname]
+      end
+
+      # http://foo-o-rama.com/vagrant--stdin-is-not-a-tty--fix.html
+      proxy.vm.provision "fix-no-tty", type: "shell" do |s|
+          s.privileged = false
+          s.inline = "sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile"
+      end
+
+      proxy.vm.provision "update system packages", type: "shell" do |s|
+        s.privileged = true
+        s.inline = "apt-get update && apt-get upgrade -Vy --force-yes"
+      end
+
+      proxy.vm.provision "update hosts", type: "shell" do |s|
+        s.privileged = true
+        s.inline = "echo \"#{settings['admin']['ip']} salt\" >> /etc/hosts"
+      end
+
+      proxy.vm.provision :salt do |saltminion|
+        saltminion.masterless = false
+        saltminion.minion_id = hostname
+        saltminion.minion_config = "salt/minion/conf"
+        saltminion.grains_config = "salt/minion/grains/proxy"
+        saltminion.run_highstate = false
+        saltminion.bootstrap_options = '-F -c /tmp/ -P'
       end
     end
   end
@@ -65,14 +156,13 @@ Vagrant.configure("2") do |config|
       storage.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
       storage.vm.box = "trusty64"
       storage.vm.hostname = hostname
-
-      storage.vm.network :private_network, ip: "10.0.0.20#{i}"
+      storage.vm.network :private_network, ip: "#{settings['general']['network']}.20#{i}"
 
       storage.vm.provider :virtualbox do |v|
         v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
         v.customize ["modifyvm", :id, "--memory", 1024]
         v.customize ["modifyvm", :id, "--name", hostname]
-	v.customize ["storagectl", :id, "--name", "SATAController", "--portcount", 11]
+        v.customize ["storagectl", :id, "--name", "SATAController", "--portcount", 11]
 
         (1..10).each do |j|
           file_to_disk = "./tmp/#{hostname}-d#{j}.vdi"
@@ -91,6 +181,31 @@ Vagrant.configure("2") do |config|
         v.customize ['storageattach', :id, '--storagectl', 'SATAController', '--port', 8, '--device', 0, '--type', 'hdd', '--medium', "./tmp/#{hostname}-d8.vdi"]
         v.customize ['storageattach', :id, '--storagectl', 'SATAController', '--port', 9, '--device', 0, '--type', 'hdd', '--medium', "./tmp/#{hostname}-d9.vdi"]
         v.customize ['storageattach', :id, '--storagectl', 'SATAController', '--port', 10, '--device', 0, '--type', 'hdd', '--medium', "./tmp/#{hostname}-d10.vdi"]
+      end
+
+      # http://foo-o-rama.com/vagrant--stdin-is-not-a-tty--fix.html
+      storage.vm.provision "fix-no-tty", type: "shell" do |s|
+          s.privileged = false
+          s.inline = "sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile"
+      end
+
+      storage.vm.provision "update system packages", type: "shell" do |s|
+        s.privileged = true
+        s.inline = "apt-get update && apt-get upgrade -Vy --force-yes"
+      end
+
+      storage.vm.provision "update hosts", type: "shell" do |s|
+        s.privileged = true
+        s.inline = "echo \"#{settings['admin']['ip']} salt\" >> /etc/hosts"
+      end
+
+      storage.vm.provision :salt do |saltminion|
+        saltminion.masterless = false
+        saltminion.minion_id = hostname
+        saltminion.minion_config = "salt/minion/conf"
+        saltminion.grains_config = "salt/minion/grains/storage"
+        saltminion.run_highstate = false
+        saltminion.bootstrap_options = '-F -c /tmp/ -P'
       end
     end
   end

--- a/example.local.yaml
+++ b/example.local.yaml
@@ -1,5 +1,7 @@
 general:
   network: 10.0.0
+admin:
+  ip: 10.0.0.10
 lb:
   host_port: 8080
 proxy:

--- a/salt/README.md
+++ b/salt/README.md
@@ -1,0 +1,99 @@
+Saltstack for a multi-node Openstack Swift cluster
+==================================================
+
+This salt environment makes the following assumptions:
+
+- Any servers killed individually have salt key manually removed after destroy
+- There is one admin server.
+- There is only one server with role `statsd`
+- There is only one server with role `graphite`
+- There is only one server with role `carbon`
+- There is only one load balancer server
+- Proxy servers are named `proxy-z1`, `proxy-z2` etc.
+- Storage is named `storage-z1`, `storage-z2` etc.
+- No support for multiple nodes per zone
+- All pillar variables with `change` in value have been changed
+
+Using the vagrant environment will produce a suitable small swift cluster.
+Once all hosts are online and respond to salt commands, issue a `state.highstate` command to configure the cluster.
+
+```
+vagrant@admin1:~$ sudo salt '*' test.ping --out=txt
+storage-z1: True
+storage-z2: True
+storage-z3: True
+storage-z4: True
+lb1: True
+proxy-z1: True
+proxy-z2: True
+admin1: True
+vagrant@admin1:~$ sudo salt '*' state.highstate
+```
+
+Using the default vagrant configuration shown above will produce a cluster with the following characteristics and services.
+
+- admin1
+  - salt master server
+  - statsd, carbon-relay and graphite services
+  - centralised syslog-ng logging
+  - system metrics to graphite under servers.
+
+- proxy-z1, proxy-z2
+  - memcached running
+  - swift-proxy-server running
+  - swift-proxy logging to admin1
+  - swift memcache.conf configured with proxy-z1 and proxy-z2
+  - system metrics to graphite under servers.
+
+- lb1
+  - haproxy configured proxy-z1, proxy-z2 backend
+  - haproxy logging to local4
+  - haproxy http frontend only
+  - system metrics to graphite under servers.
+
+
+## Roles
+
+These are defined in the salt grain `roles`. To see a servers defined roles or target servers by role use these commands. Available roles are listed.
+
+```
+vagrant@admin1:~$ sudo salt 'proxy-z1' grains.item roles
+proxy-z1:
+    ----------
+    roles:
+        - swift
+        - swift-proxy
+        - memcached
+        - hourly_logs
+vagrant@admin1:~$
+vagrant@admin1:~$ sudo salt -G 'roles:memcached' test.ping --out=txt
+proxy-z1: True
+proxy-z2: True
+vagrant@admin1:~$
+vagrant@admin1:~$ sudo salt -C '* not G@roles:memcached' test.ping --out=txt
+storage-z1: True
+lb1: True
+admin1: True
+vagrant@admin1:~$
+vagrant@admin1:~$ sudo salt -C 'G@roles:memcached not *z1' test.ping --out=txt
+proxy-z2: True
+vagrant@admin1:~$
+```
+
+      Roles      | Role Info
+-----------------|---------------------------------------------------
+swift            | installs swift code and dependencies
+swift-object     | enables python swift obj server
+swift-container  | enables container server
+swift-account    | enables account server
+swift-proxy      | enables proxy server, adds to haproxy backend
+memcached        | enables memcached, adds to swift memcached config
+haproxy          | enables haproxy
+admin            | admin server for making rings, running recon etc.
+saltmaster       | salt master
+syslog           | configures syslog for remote hosts
+statsd           | enables statsd server
+carbon           | enables carbon relay
+graphite         | configures graphiteweb
+hourly_logs      | enables /var/log/swift/hourly logging
+

--- a/salt/files/etc/diamond/diamond.conf.jinja
+++ b/salt/files/etc/diamond/diamond.conf.jinja
@@ -1,0 +1,169 @@
+################################################################################
+# Diamond Configuration File
+################################################################################
+
+### Options for server
+[server]
+
+# Handlers for published metrics.
+handlers = diamond.handler.graphite.GraphiteHandler, diamond.handler.archive.ArchiveHandler
+
+# User diamond will run as. Leave empty to use the current user
+user =
+
+# Group diamond will run as. Leave empty to use the current group
+group =
+
+# Log file
+log_file = /var/log/diamond/diamond.log
+
+# Number of days to keep log files
+log_file_days = 7
+
+# Pid file
+pid_file = /var/run/diamond.pid
+
+# Directory to load collector modules from
+collectors_path = /usr/local/share/diamond/collectors/
+
+# Directory to load collector config from
+collectors_config_path = /etc/diamond/collectors/
+
+# Interval to reload collectors
+collectors_reload_interval = 3600
+
+################################################################################
+### Options for handlers
+[handlers]
+
+# daemon logging handler(s)
+keys = rotated_file
+
+### Defaults options for all Handlers
+[[default]]
+
+[[ArchiveHandler]]
+
+# File to write archive log files
+log_file = /var/log/diamond/archive.log
+
+# Number of days to keep archive log files
+days = 2
+
+[[GraphiteHandler]]
+### Options for GraphiteHandler
+
+# Graphite server host
+{% set server, graphite_addr = salt['mine.get']('roles:graphite', 'network.ip_addrs', expr_form='grain').items()[0] %}
+host = {{ graphite_addr[0] }}
+
+# Port to send metrics to
+port = 2003
+
+# Socket timeout (seconds)
+timeout = 30
+
+
+################################################################################
+### Options for collectors
+[collectors]
+
+[[default]]
+### Defaults options for all Collectors
+
+# Uncomment and set to hardcode a hostname for the collector path
+# Keep in mind, periods are seperators in graphite
+# hostname = my_custom_hostname
+
+# If you perfer to just use a different way of calculating the hostname
+# Uncomment and set this to one of these values:
+# fqdn_short  = Default. Similar to hostname -s
+# fqdn_rev    = hostname in reverse (com.example.www)
+# uname_short = Similar to uname -n, but only the first part
+# uname_rev   = uname -r in reverse (com.example.www)
+# hostname_method = fqdn_short
+
+# All collectors are disabled by default
+enabled = False
+
+# Path Prefix
+path_prefix = servers
+
+# Default splay time (seconds)
+splay = 1
+
+# Default Poll Interval (seconds)
+interval = 300
+
+# Default collector threading model
+method = Sequential
+
+# Default numeric output
+byte_unit = byte
+
+[[CPUCollector]]
+enabled = True
+
+[[DiskSpaceCollector]]
+enabled = True
+exclude_filters = ^/boot
+byte_unit = gigabyte,
+
+[[SockstatCollector]]
+enabled = True
+
+[[NetworkCollector]]
+enabled = True
+byte_unit = megabit,
+
+[[DiskUsageCollector]]
+enabled = True
+
+[[LoadAverageCollector]]
+enabled = True
+
+[[MemoryCollector]]
+enabled = True
+
+[[VMStatCollector]]
+enabled = True
+
+
+
+
+################################################################################
+### Options for logging
+# for more information on file format syntax:
+# http://docs.python.org/library/logging.config.html#configuration-file-format
+
+[loggers]
+
+keys = root
+
+# handlers are higher in this config file, in:
+# [handlers]
+# keys = ...
+
+[formatters]
+
+keys = default
+
+[logger_root]
+
+# to increase verbosity, set DEBUG
+level = INFO
+handlers = rotated_file
+propagate = 1
+
+[handler_rotated_file]
+
+class = handlers.TimedRotatingFileHandler
+level = DEBUG
+formatter = default
+# rotate at midnight, each day and keep 7 days
+args = ('/var/log/diamond/diamond.log', 'midnight', 1, 7)
+
+[formatter_default]
+
+format = [%(asctime)s] [%(threadName)s] %(message)s
+datefmt =

--- a/salt/files/etc/haproxy/haproxy.cfg.jinja
+++ b/salt/files/etc/haproxy/haproxy.cfg.jinja
@@ -1,0 +1,43 @@
+global
+    log       127.0.0.1 local4
+    log-send-hostname
+    maxconn   {{ pillar['haproxy_global_maxconn'] }}
+    tune.bufsize 65536
+    user      haproxy
+    group     haproxy
+    nbproc    {{ pillar['haproxy_nbproc'] }}
+    daemon
+
+defaults
+    mode            http
+    balance         roundrobin
+    option          httplog
+    option          log-separate-errors
+    option          dontlognull
+    option          http-server-close
+    option          tcp-smart-accept
+    option          tcp-smart-connect
+    option          accept-invalid-http-response
+    option          splice-auto
+    retries         3
+    timeout connect 4s
+    timeout client  700s
+    timeout server  120s
+    timeout queue   10s
+    timeout http-request 10s
+    timeout http-keep-alive 5s
+
+frontend swift-storage
+    log     global
+    maxconn {{ pillar['haproxy_frontend_maxconn'] }}
+    bind    {{ pillar['haproxy_listen'] }}
+    default_backend proxy_pool
+
+backend proxy_pool
+    option  httpchk GET /healthcheck
+    option  forwardfor
+    fullconn 9000
+    {% for server, addrs in salt['mine.get']('roles:swift-proxy', 'network.ip_addrs', expr_form='grain') | dictsort() %}
+    server {{ server }} {{ addrs[0] }}:80 check inter 3000 rise 3 fall 5
+    {%- endfor %}
+

--- a/salt/files/etc/memcached.conf.jinja
+++ b/salt/files/etc/memcached.conf.jinja
@@ -1,0 +1,47 @@
+# memcached default config file
+# 2003 - Jay Bonci <jaybonci@debian.org>
+# This configuration file is read by the start-memcached script provided as
+# part of the Debian GNU/Linux distribution.
+
+# Run memcached as a daemon. This command is implied, and is not needed for the
+# daemon to run. See the README.Debian that comes with this package for more
+# information.
+-d
+
+# Log memcached's output to /var/log/memcached
+logfile /var/log/memcached.log
+
+# Be verbose
+# -v
+
+# Be even more verbose (print client commands as well)
+# -vv
+
+# Start with a cap of 64 megs of memory. It's reasonable, and the daemon default
+# Note that the daemon will grow to this size, but does not start out holding this much
+# memory
+-m {{ pillar['memcache']['memory'] }}
+
+# Default connection port is 11211
+-p 11211
+
+# Run the daemon as root. The start-memcached will default to running as root if no
+# -u command is present in this config file
+-u root
+
+# Specify which IP address to listen on. The default is to listen on all IP addresses
+# This parameter is one of the only security measures that memcached has, so make sure
+# it's listening on a firewalled interface.
+-l 0.0.0.0
+
+# Limit the number of simultaneous incoming connections. The daemon default is 1024
+-c {{ pillar['memcache']['simultaneous_conn'] }}
+
+# Lock down all paged memory. Consult with the README and homepage before you do this
+# -k
+
+# Return error when memory is exhausted (rather than removing items)
+# -M
+
+# Maximize core file limit
+# -r

--- a/salt/files/etc/supervisor/conf.d/conf.jinja
+++ b/salt/files/etc/supervisor/conf.d/conf.jinja
@@ -1,0 +1,8 @@
+[program:{{ processname }}]
+user = {{ run_as }}
+command = {{ command }}
+stdout_logfile = /var/log/supervisor/{{ processname }}.log
+stderr_logfile = /var/log/supervisor/{{ processname }}.err
+autorestart = {{ autorestart }}
+autostart = {{ autostart }}
+directory = {{ directory }}

--- a/salt/files/etc/swift/memcache.conf.jinja
+++ b/salt/files/etc/swift/memcache.conf.jinja
@@ -1,0 +1,31 @@
+[memcache]
+# You can use this single conf file instead of having memcache_servers set in
+# several other conf files under [filter:cache] for example. You can specify
+# multiple servers separated with commas, as in: 10.1.2.3:11211,10.1.2.4:11211
+# (IPv6 addresses must follow rfc3986 section-3.2.2, i.e. [::1]:11211)
+{%- set memcache_servers = [] %}
+{%- for _, ip in salt['mine.get']('roles:memcached', 'network.ip_addrs', expr_form='grain').items() %}
+{%- do  memcache_servers.append(ip[0] + ":11211") %}
+{%- endfor %}
+memcache_servers = {{ memcache_servers|join(',') }}
+# Sets how memcache values are serialized and deserialized:
+# 0 = older, insecure pickle serialization
+# 1 = json serialization but pickles can still be read (still insecure)
+# 2 = json serialization only (secure and the default)
+# To avoid an instant full cache flush, existing installations should
+# upgrade with 0, then set to 1 and reload, then after some time (24 hours)
+# set to 2 and reload.
+# In the future, the ability to use pickle serialization will be removed.
+# memcache_serialization_support = 2
+#
+# Sets the maximum number of connections to each memcached server per worker
+# memcache_max_connections = 2
+#
+# Timeout for connection
+# connect_timeout = 0.3
+# Timeout for pooled connection
+# pool_timeout = 1.0
+# number of servers to retry on failures getting a pooled connection
+# tries = 3
+# Timeout for read and writes
+# io_timeout = 2.0

--- a/salt/files/etc/swift/proxy.d/mime.types
+++ b/salt/files/etc/swift/proxy.d/mime.types
@@ -1,0 +1,1 @@
+application/json                                json

--- a/salt/files/etc/swift/proxy.d/proxy-server.conf.jinja
+++ b/salt/files/etc/swift/proxy.d/proxy-server.conf.jinja
@@ -1,0 +1,88 @@
+[DEFAULT]
+workers = {{ pillar['swift']['proxy']['workers'] }}
+bind_port = 80
+trans_id_suffix = {{ pillar['swift']['proxy']['trans_id_suffix'] }}
+log_max_line_length = {{ pillar['swift']['proxy']['log_max_line_length'] }}
+log_udp_host = 127.0.0.1
+log_udp_port = 514
+
+[pipeline:main]
+pipeline = {{ pillar['swift']['proxy']['pipeline'] }}
+
+[app:proxy-server]
+use = egg:swift#proxy
+set log_facility = LOG_LOCAL0
+allow_account_management = {{ pillar['swift']['proxy']['allow_account_management'] }}
+account_autocreate = {{ pillar['swift']['proxy']['account_autocreate'] }}
+log_handoffs = {{ pillar['swift']['proxy']['log_handoffs'] }}
+max_containers_per_account = {{ pillar['swift']['proxy']['max_containers_per_account'] }}
+max_containers_whitelist = {{ pillar['swift']['proxy']['max_containers_whitelist'] }}
+strict_cors_mode = {{ pillar['swift']['proxy']['strict_cors_mode'] }}
+request_node_count = {{ pillar['swift']['proxy']['request_node_count'] }}
+recoverable_node_timeout = {{ pillar['swift']['proxy']['recoverable_node_timeout'] }}
+node_timeout = {{ pillar['swift']['proxy']['node_timeout'] }}
+conn_timeout = {{ pillar['swift']['proxy']['conn_timeout'] }}
+
+[filter:healthcheck]
+use = egg:swift#healthcheck
+disable_path = {{ pillar['swift']['proxy']['healthcheck_disable_path'] }}
+
+[filter:swauth]
+use = egg:swauth#swauth
+set log_facility = LOG_LOCAL0
+reseller_prefix = {{ pillar['swift']['proxy']['swauth_reseller_prefix'] }}
+auth_prefix = /auth/
+default_swift_cluster = {{ pillar['swift']['proxy']['swauth_default_swift_cluster'] }}
+super_admin_key = {{ pillar['swift']['proxy']['swauth_super_admin_key'] }}
+
+[filter:proxy-logging]
+use = egg:swift#proxy_logging
+
+[filter:cache]
+use = egg:swift#memcache
+memcache_serialization_support = {{ pillar['swift']['proxy']['memcache_serialization_support'] }}
+
+[filter:bulk]
+use = egg:swift#bulk
+yield_frequency = {{ pillar['swift']['proxy']['bulk_yield_frequency'] }}
+
+[filter:slo]
+use = egg:swift#slo
+
+[filter:container-quotas]
+use = egg:swift#container_quotas
+
+[filter:ratelimit]
+use = egg:swift#ratelimit
+container_ratelimit_0 = {{ pillar['swift']['proxy']['container_ratelimit'] }}
+account_ratelimit = {{ pillar['swift']['proxy']['account_ratelimit'] }}
+account_whitelist = {{ pillar['swift']['proxy']['account_whitelist'] }}
+
+[filter:catch_errors]
+use = egg:swift#catch_errors
+
+[filter:staticweb]
+use = egg:swift#staticweb
+
+[filter:informant]
+use = egg:informant#informant
+{% set server, statsd_addr = salt['mine.get']('roles:statsd', 'network.ip_addrs', expr_form='grain').items()[0] %}
+statsd_host = {{ statsd_addr[0] }}
+statsd_port = 8125
+standard statsd sample rate 0.0 <= 1
+statsd_sample_rate = {{ pillar['swift']['proxy']['informant_statsd_sample_rate'] }}
+combined_events = {{ pillar['swift']['proxy']['informant_combined_events'] }}
+metric_name_prepend = servers.{{ grains['nodename']|lower() }}.
+
+[filter:tempurl]
+use = egg:swift#tempurl
+methods = {{ pillar['swift']['proxy']['tempurl_methods'] }}
+
+[filter:formpost]
+use = egg:swift#formpost
+
+[filter:dlo]
+use = egg:swift#dlo
+
+[filter:gatekeeper]
+use = egg:swift#gatekeeper

--- a/salt/files/etc/swift/swift.conf.jinja
+++ b/salt/files/etc/swift/swift.conf.jinja
@@ -1,0 +1,4 @@
+[swift-hash]
+# random unique string that can never change (DO NOT LOSE)
+swift_hash_path_suffix = {{ pillar['swift_hash_path_suffix'] }}
+swift_hash_path_prefix = {{ pillar['swift_hash_path_prefix'] }}

--- a/salt/files/etc/syslog-ng/syslog-ng.conf.jinja
+++ b/salt/files/etc/syslog-ng/syslog-ng.conf.jinja
@@ -1,0 +1,286 @@
+@version: 3.5
+@include "scl.conf"
+
+{% set server, listen_addr = salt['mine.get']('roles:syslog', 'network.ip_addrs', expr_form='grain').items()[0] %}
+
+options {
+        chain_hostnames(0);
+        time_reopen(10);
+        time_reap(360);
+        log_fifo_size({{ pillar['syslog_log_fifo_size'] }});
+        create_dirs(yes);
+        owner("root");
+        group("adm");
+        perm(0640);
+        #dir_owner(root);
+        #dir_group(root);
+        dir_perm(0755);
+        use_dns(no);
+        log_msg_size(9216);
+        stats_freq(600);
+        bad_hostname("^gconfd$");
+        flush_lines(0);
+        use_fqdn(no);
+};
+
+source s_src {
+        system();
+        internal();
+        syslog(flags("no-multi-line"));
+        unix-stream("/dev/log" flags("no-multi-line"));
+        file("/proc/kmsg" program_override("kernel: "));
+        udp(ip(127.0.0.1));
+        {%- if 'syslog' in grains['roles'] %}
+        tcp(ip("0.0.0.0") port(514) max-connections(1000) log_iw_size(400000) log_fetch_limit(100) );
+        {%- endif %}
+};
+
+destination d_auth { file("/var/log/auth.log"); };
+destination d_cron { file("/var/log/cron.log"); };
+destination d_daemon { file("/var/log/daemon.log"); };
+destination d_kern { file("/var/log/kern.log"); };
+destination d_lpr { file("/var/log/lpr.log"); };
+destination d_mail { file("/var/log/mail.log"); };
+destination d_syslog { file("/var/log/syslog"); };
+destination d_user { file("/var/log/user.log"); };
+destination d_uucp { file("/var/log/uucp.log"); };
+destination d_healthchk { file("/var/log/swift/healthchk.log"); };
+destination d_local0 { file("/var/log/swift/proxy.log"); };
+destination d_local0_err { file("/var/log/swift/proxy.error"); };
+{%- if 'hourly_logs' in grains['roles'] %}
+destination d_local0_hourly { file("/var/log/swift/hourly/$YEAR$MONTH$DAY$HOUR"); };
+{%- endif %}
+destination d_local1 { file("/var/log/swift/storage.log"); };
+destination d_local1_err { file("/var/log/swift/storage.error"); };
+destination d_local2 { file("/var/log/swift/jobs.log"); };
+destination d_local2_err { file("/var/log/swift/jobs.error"); };
+destination d_local3 { file("/var/log/swift/drive-audit.log"); };
+destination d_local3_err { file("/var/log/swift/drive-audit.error"); };
+destination d_local4 { file("/var/log/haproxy.log"); };
+destination d_local4_err { file("/var/log/haproxy.error"); };
+{%- if 'syslog' not in grains['roles'] %}
+destination d_remote { tcp({{ listen_addr[0] }} port(514)); };
+{%- endif %}
+{%- if 'statsdlog' in grains['roles'] %}
+destination df_local_statsdlog { udp(127.0.0.1 port(8126)); #route to local statsdlog server };
+{%- endif %}
+destination d_mailinfo { file("/var/log/mail/mail.info"); };
+destination d_mailwarn { file("/var/log/mail/mail.warn"); };
+destination d_mailerr { file("/var/log/mail/mail.err"); };
+destination d_newscrit { file("/var/log/news/news.crit"); };
+destination d_newserr { file("/var/log/news/news.err"); };
+destination d_newsnotice { file("/var/log/news/news.notice"); };
+destination d_debug { file("/var/log/debug"); };
+destination d_error { file("/var/log/error"); };
+destination d_messages { file("/var/log/messages"); };
+destination d_console { usertty("root"); };
+destination d_console_all { file("/dev/tty10"); };
+destination d_xconsole { pipe("/dev/xconsole"); };
+destination d_ppp { file("/var/log/ppp.log"); };
+
+filter f_local0 { facility(local0) and level(info,debug) and
+            not ( match("GET /healthcheck HTTP/1.0" value("MSG"))
+                or match("GET /healthcheck HTTP/1.1" value("MSG"))
+                or match("GET /lbstats%3Bcsv%3Bnorefresh HTTP/1.1" value("MSG"))
+                or match("GET /lbstats%3Bcsv%3Bnorefresh HTTP/1.0" value("MSG"))); };
+
+filter f_local0_err { facility(local0) and not level(info,debug) and
+            not ( match("GET /healthcheck HTTP/1.0" value("MSG"))
+                or match("GET /healthcheck HTTP/1.1" value("MSG"))
+                or match("GET /lbstats%3Bcsv%3Bnorefresh HTTP/1.1" value("MSG"))
+                or match("GET /lbstats%3Bcsv%3Bnorefresh HTTP/1.0" value("MSG"))); };
+
+filter f_healthchk { match("GET /healthcheck HTTP/1.0" value("MSG"))
+            or match("GET /healthcheck HTTP/1.1" value("MSG"))
+            or match("GET /lbstats%3Bcsv%3Bnorefresh HTTP/1.1" value("MSG"))
+            or match("GET /lbstats%3Bcsv%3Bnorefresh HTTP/1.0" value("MSG")); };
+
+filter f_local1 { facility(local1) and level(info,debug); };
+filter f_local1_err { facility(local1) and not level(info,debug); };
+filter f_local2 { facility(local2) and level(info,debug); };
+filter f_local2_err { facility(local2) and not level(info,debug); };
+filter f_local3 { facility(local3) and level(info,debug); };
+filter f_local3_err { facility(local3) and not level(info,debug); };
+filter f_local4 { facility(local4) and level(info,debug); };
+filter f_local4_err { facility(local4) and not level(info,debug); };
+filter f_dbg { level(debug); };
+filter f_info { level(info); };
+filter f_notice { level(notice); };
+filter f_warn { level(warn); };
+filter f_err { level(err); };
+filter f_crit { level(crit .. emerg); };
+filter f_debug { level(debug) and not facility(auth, authpriv, news, mail); };
+filter f_error { level(err .. emerg) and not facility(local0, local1, local2, local3); };
+filter f_messages { level(info,notice,warn) and not facility(auth,authpriv,cron,daemon,mail,news,local0, local1, local2, local3); };
+filter f_auth { facility(auth, authpriv) and not filter(f_debug); };
+filter f_cron { facility(cron) and not filter(f_debug); };
+filter f_daemon { facility(daemon) and not filter(f_debug); };
+filter f_kern { facility(kern) and not filter(f_debug); };
+filter f_lpr { facility(lpr) and not filter(f_debug); };
+filter f_local { facility(local0, local1, local3, local4) and not filter(f_debug); };
+filter f_mail { facility(mail) and not filter(f_debug); };
+filter f_news { facility(news) and not filter(f_debug); };
+filter f_syslog3 {  not facility(auth, authpriv, mail, local0, local1, local2, local3, local4) and not filter(f_debug); };
+filter f_user { facility(user) and not filter(f_debug); };
+filter f_uucp { facility(uucp) and not filter(f_debug); };
+filter f_cnews { level(notice, err, crit) and facility(news); };
+filter f_cother { level(debug, info, notice, warn) or facility(daemon, mail); };
+filter f_ppp { facility(local2) and not filter(f_debug); };
+filter f_console { level(warn .. emerg); };
+
+log { source(s_src); filter(f_auth); destination(d_auth); };
+log { source(s_src); filter(f_cron); destination(d_cron); };
+log { source(s_src); filter(f_daemon); destination(d_daemon); };
+log { source(s_src); filter(f_kern); destination(d_kern); };
+log { source(s_src); filter(f_lpr); destination(d_lpr); };
+log { source(s_src); filter(f_syslog3); destination(d_syslog); };
+log { source(s_src); filter(f_user); destination(d_user); };
+log { source(s_src); filter(f_uucp); destination(d_uucp); };
+log { source(s_src); filter(f_mail); destination(d_mail); };
+#log { source(s_src); filter(f_mail); filter(f_info); destination(d_mailinfo); };
+#log { source(s_src); filter(f_mail); filter(f_warn); destination(d_mailwarn); };
+#log { source(s_src); filter(f_mail); filter(f_err); destination(d_mailerr); };
+log { source(s_src); filter(f_news); filter(f_crit); destination(d_newscrit); };
+log { source(s_src); filter(f_news); filter(f_err); destination(d_newserr); };
+log { source(s_src); filter(f_news); filter(f_notice); destination(d_newsnotice); };
+#log { source(s_src); filter(f_cnews); destination(d_console_all); };
+#log { source(s_src); filter(f_cother); destination(d_console_all); };
+#log { source(s_src); filter(f_ppp); destination(d_ppp); };
+log { source(s_src); filter(f_debug); destination(d_debug); };
+log { source(s_src); filter(f_error); destination(d_error); };
+log { source(s_src); filter(f_messages); destination(d_messages); };
+log { source(s_src); filter(f_console); destination(d_console_all); destination(d_xconsole); };
+log { source(s_src); filter(f_crit); destination(d_console); };
+
+# local0.info                        -/var/log/swift/proxy.log
+# write to local file and to remove log server
+log {
+        source(s_src);
+        filter(f_local0);
+        destination(d_local0);
+        {%- if 'hourly_logs' in grains['roles'] %}
+        destination(d_local0_hourly);
+        {%- endif %}
+        {%- if 'syslog' not in grains['roles'] %}
+        destination(d_remote);
+        {%- endif %}
+};
+
+# local0.error                        -/var/log/swift/proxy.error
+# write to local file and to remove log server
+log {
+        source(s_src);
+        filter(f_local0_err);
+        destination(d_local0_err);
+        {%- if 'syslog' not in grains['roles'] %}
+        destination(d_remote);
+        {%- endif %}
+        {%- if 'statsdlog' in grains['roles'] -%}
+        destination(df_local_statsdlog);
+        {% endif %}
+};
+
+# Puts all health check into a local file
+log {
+        source(s_src);
+        filter(f_healthchk);
+        destination(d_healthchk);
+};
+
+# local1.info                        -/var/log/swift/storage.log
+# write to local file and to remote log server
+log {
+        source(s_src);
+        filter(f_local1);
+        destination(d_local1);
+        {%- if 'syslog' not in grains['roles'] %}
+        destination(d_remote);
+        {%- endif %}
+};
+
+# local1.error                        -/var/log/swift/storage.error
+# write to local file and to remote log server
+log {
+        source(s_src);
+        filter(f_local1_err);
+        destination(d_local1_err);
+        {%- if 'syslog' not in grains['roles'] %}
+        destination(d_remote);
+        {%- endif %}
+        {%- if 'statsdlog' in grains['roles'] -%}
+        destination(df_local_statsdlog);
+        {% endif %}
+
+};
+
+# local2.info                        -/var/log/swift/jobs.log
+# write to local file and to remote log server
+log {
+        source(s_src);
+        filter(f_local2);
+        destination(d_local2);
+        {%- if 'syslog' not in grains['roles'] %}
+        destination(d_remote);
+        {%- endif %}
+};
+
+# local2.error                        -/var/log/swift/jobs.error
+# write to local file and to remote log server
+log {
+        source(s_src);
+        filter(f_local2_err);
+        destination(d_local2_err);
+        {%- if 'syslog' not in grains['roles'] %}
+        destination(d_remote);
+        {%- endif %}
+        {%- if 'statsdlog' in grains['roles'] -%}
+        destination(df_local_statsdlog);
+        {% endif %}
+};
+
+# local3.info                        -/var/log/swift/drive-audit.log
+# write to local file and to remote log server
+log {
+        source(s_src);
+        filter(f_local3);
+        destination(d_local3);
+};
+
+# local3.error                        -/var/log/swift/drive-audit.error
+# write to local file and to remote log server
+log {
+        source(s_src);
+        filter(f_local3_err);
+        destination(d_local3_err);
+        {%- if 'statsdlog' in grains['roles'] -%}
+        destination(df_local_statsdlog);
+        {% endif %}
+};
+
+# local4.info                        -/var/log/haproxy.log
+# write to local file and to remote log server
+log {
+        source(s_src);
+        filter(f_local4);
+        destination(d_local4);
+        {%- if 'syslog' not in grains['roles'] %}
+        destination(d_remote);
+        {%- endif %}
+
+};
+
+# local4.error                        -/var/log/haproxy.error
+# write to local file and to remote log server
+log {
+        source(s_src);
+        filter(f_local4_err);
+        destination(d_local4_err);
+        {%- if 'syslog' not in grains['roles'] %}
+        destination(d_remote);
+        {%- endif %}
+        {%- if 'statsdlog' in grains['roles'] -%}
+        destination(df_local_statsdlog);
+        {% endif %}
+};
+
+#@include "/etc/syslog-ng/conf.d/*.conf"

--- a/salt/files/opt/graphite/conf/carbon.conf.jinja
+++ b/salt/files/opt/graphite/conf/carbon.conf.jinja
@@ -1,0 +1,280 @@
+[cache]
+# Configure carbon directories.
+#
+# OS environment variables can be used to tell carbon where graphite is
+# installed, where to read configuration from and where to write data.
+#
+#   GRAPHITE_ROOT        - Root directory of the graphite installation.
+#                          Defaults to ../
+#   GRAPHITE_CONF_DIR    - Configuration directory (where this file lives).
+#                          Defaults to $GRAPHITE_ROOT/conf/
+#   GRAPHITE_STORAGE_DIR - Storage directory for whipser/rrd/log/pid files.
+#                          Defaults to $GRAPHITE_ROOT/storage/
+#
+# To change other directory paths, add settings to this file. The following
+# configuration variables are available with these default values:
+#
+#   STORAGE_DIR    = $GRAPHITE_STORAGE_DIR
+#   LOCAL_DATA_DIR = STORAGE_DIR/whisper/
+#   WHITELISTS_DIR = STORAGE_DIR/lists/
+#   CONF_DIR       = STORAGE_DIR/conf/
+#   LOG_DIR        = STORAGE_DIR/log/
+#   PID_DIR        = STORAGE_DIR/
+#
+# For FHS style directory structures, use:
+#
+#   STORAGE_DIR    = /var/lib/carbon/
+#   CONF_DIR       = /etc/carbon/
+#   LOG_DIR        = /var/log/carbon/
+#   PID_DIR        = /var/run/
+#
+#LOCAL_DATA_DIR = /opt/graphite/storage/whisper/
+
+# Specify the user to drop privileges to
+# If this is blank carbon runs as the user that invokes it
+# This user must have write access to the local data directory
+USER = root
+
+# Limit the size of the cache to avoid swapping or becoming CPU bound.
+# Sorts and serving cache queries gets more expensive as the cache grows.
+# Use the value "inf" (infinity) for an unlimited cache size.
+MAX_CACHE_SIZE = inf
+
+# Limits the number of whisper update_many() calls per second, which effectively
+# means the number of write requests sent to the disk. This is intended to
+# prevent over-utilizing the disk and thus starving the rest of the system.
+# When the rate of required updates exceeds this, then carbon's caching will
+# take effect and increase the overall throughput accordingly.
+MAX_UPDATES_PER_SECOND = 5000
+
+# Softly limits the number of whisper files that get created each minute.
+# Setting this value low (like at 50) is a good way to ensure your graphite
+# system will not be adversely impacted when a bunch of new metrics are
+# sent to it. The trade off is that it will take much longer for those metrics'
+# database files to all get created and thus longer until the data becomes usable.
+# Setting this value high (like "inf" for infinity) will cause graphite to create
+# the files quickly but at the risk of slowing I/O down considerably for a while.
+MAX_CREATES_PER_MINUTE = 1000
+
+LINE_RECEIVER_INTERFACE = 0.0.0.0
+LINE_RECEIVER_PORT = 2013
+
+# Set this to True to enable the UDP listener. By default this is off
+# because it is very common to run multiple carbon daemons and managing
+# another (rarely used) port for every carbon instance is not fun.
+ENABLE_UDP_LISTENER = False
+UDP_RECEIVER_INTERFACE = 0.0.0.0
+UDP_RECEIVER_PORT = 2013
+
+PICKLE_RECEIVER_INTERFACE = 0.0.0.0
+PICKLE_RECEIVER_PORT = 2014
+
+# Per security concerns outlined in Bug #817247 the pickle receiver
+# will use a more secure and slightly less efficient unpickler.
+# Set this to True to revert to the old-fashioned insecure unpickler.
+USE_INSECURE_UNPICKLER = False
+
+CACHE_QUERY_INTERFACE = 0.0.0.0
+CACHE_QUERY_PORT = 7002
+
+# Set this to False to drop datapoints received after the cache
+# reaches MAX_CACHE_SIZE. If this is True (the default) then sockets
+# over which metrics are received will temporarily stop accepting
+# data until the cache size falls below 95% MAX_CACHE_SIZE.
+USE_FLOW_CONTROL = True
+
+# By default, carbon-cache will log every whisper update. This can be excessive and
+# degrade performance if logging on the same volume as the whisper data is stored.
+LOG_UPDATES = False
+
+# On some systems it is desirable for whisper to write synchronously.
+# Set this option to True if you'd like to try this. Basically it will
+# shift the onus of buffering writes from the kernel into carbon's cache.
+WHISPER_AUTOFLUSH = False
+
+# By default new Whisper files are created pre-allocated with the data region
+# filled with zeros to prevent fragmentation and speed up contiguous reads and
+# writes (which are common). Enabling this option will cause Whisper to create
+# the file sparsely instead. Enabling this option may allow a large increase of
+# MAX_CREATES_PER_MINUTE but may have longer term performance implications
+# depending on the underlying storage configuration.
+# WHISPER_SPARSE_CREATE = False
+
+# Enabling this option will cause Whisper to lock each Whisper file it writes
+# to with an exclusive lock (LOCK_EX, see: man 2 flock). This is useful when
+# multiple carbon-cache daemons are writing to the same files
+# WHISPER_LOCK_WRITES = False
+
+# Set this to True to enable whitelisting and blacklisting of metrics in
+# CONF_DIR/whitelist and CONF_DIR/blacklist. If the whitelist is missing or
+# empty, all metrics will pass through
+# USE_WHITELIST = False
+
+# By default, carbon itself will log statistics (such as a count,
+# metricsReceived) with the top level prefix of 'carbon' at an interval of 60
+# seconds. Set CARBON_METRIC_INTERVAL to 0 to disable instrumentation
+CARBON_METRIC_PREFIX = carbon
+CARBON_METRIC_INTERVAL = 60
+
+# Enable AMQP if you want to receve metrics using an amqp broker
+# ENABLE_AMQP = False
+
+# Verbose means a line will be logged for every metric received
+# useful for testing
+# AMQP_VERBOSE = False
+
+# AMQP_HOST = localhost
+# AMQP_PORT = 5672
+# AMQP_VHOST = /
+# AMQP_USER = guest
+# AMQP_PASSWORD = guest
+# AMQP_EXCHANGE = graphite
+# AMQP_METRIC_NAME_IN_BODY = False
+
+# The manhole interface allows you to SSH into the carbon daemon
+# and get a python interpreter. BE CAREFUL WITH THIS! If you do
+# something like time.sleep() in the interpreter, the whole process
+# will sleep! This is *extremely* helpful in debugging, assuming
+# you are familiar with the code. If you are not, please don't
+# mess with this, you are asking for trouble :)
+#
+# ENABLE_MANHOLE = False
+# MANHOLE_INTERFACE = 127.0.0.1
+# MANHOLE_PORT = 7222
+# MANHOLE_USER = admin
+# MANHOLE_PUBLIC_KEY = ssh-rsa AAAAB3NzaC1yc2EAAAABiwAaAIEAoxN0sv/e4eZCPpi3N3KYvyzRaBaMeS2RsOQ/cDuKv11dlNzVeiyc3RFmCv5Rjwn/lQ79y0zyHxw67qLyhQ/kDzINc4cY41ivuQXm2tPmgvexdrBv5nsfEpjs3gLZfJnyvlcVyWK/lId8WUvEWSWHTzsbtmXAF2raJMdgLTbQ8wE=
+
+# Patterns for all of the metrics this machine will store. Read more at
+# http://en.wikipedia.org/wiki/Advanced_Message_Queuing_Protocol#Bindings
+#
+# Example: store all sales, linux servers, and utilization metrics
+# BIND_PATTERNS = sales.#, servers.linux.#, #.utilization
+#
+# Example: store everything
+# BIND_PATTERNS = #
+
+# To configure special settings for the carbon-cache instance 'b', uncomment this:
+#[cache:b]
+#LINE_RECEIVER_PORT = 2103
+#PICKLE_RECEIVER_PORT = 2104
+#CACHE_QUERY_PORT = 7102
+# and any other settings you want to customize, defaults are inherited
+# from [carbon] section.
+# You can then specify the --instance=b option to manage this instance
+
+
+
+[relay]
+LINE_RECEIVER_INTERFACE = 0.0.0.0
+LINE_RECEIVER_PORT = 2003
+PICKLE_RECEIVER_INTERFACE = 0.0.0.0
+PICKLE_RECEIVER_PORT = 2004
+
+# To use consistent hashing instead of the user defined relay-rules.conf,
+# change this to:
+# RELAY_METHOD = consistent-hashing
+RELAY_METHOD = rules
+
+# If you use consistent-hashing you may want to add redundancy
+# of your data by replicating every datapoint to more than
+# one machine.
+REPLICATION_FACTOR = 1
+
+# This is a list of carbon daemons we will send any relayed or
+# generated metrics to. The default provided would send to a single
+# carbon-cache instance on the default port. However if you
+# use multiple carbon-cache instances then it would look like this:
+#
+# DESTINATIONS = 127.0.0.1:2004:a, 127.0.0.1:2104:b
+#
+# The general form is IP:PORT:INSTANCE where the :INSTANCE part is
+# optional and refers to the "None" instance if omitted.
+#
+# Note that if the destinations are all carbon-caches then this should
+# exactly match the webapp's CARBONLINK_HOSTS setting in terms of
+# instances listed (order matters!).
+#
+# If using RELAY_METHOD = rules, all destinations used in relay-rules.conf
+# must be defined in this list
+DESTINATIONS = 127.0.0.1:2013
+
+# This defines the maximum "message size" between carbon daemons.
+# You shouldn't need to tune this unless you really know what you're doing.
+MAX_DATAPOINTS_PER_MESSAGE = 500
+MAX_QUEUE_SIZE = 10000
+
+# Set this to False to drop datapoints when any send queue (sending datapoints
+# to a downstream carbon daemon) hits MAX_QUEUE_SIZE. If this is True (the
+# default) then sockets over which metrics are received will temporarily stop accepting
+# data until the send queues fall below 80% MAX_QUEUE_SIZE.
+USE_FLOW_CONTROL = True
+
+# Set this to True to enable whitelisting and blacklisting of metrics in
+# CONF_DIR/whitelist and CONF_DIR/blacklist. If the whitelist is missing or
+# empty, all metrics will pass through
+# USE_WHITELIST = False
+
+# By default, carbon itself will log statistics (such as a count,
+# metricsReceived) with the top level prefix of 'carbon' at an interval of 60
+# seconds. Set CARBON_METRIC_INTERVAL to 0 to disable instrumentation
+# CARBON_METRIC_PREFIX = carbon
+# CARBON_METRIC_INTERVAL = 60
+
+
+[aggregator]
+LINE_RECEIVER_INTERFACE = 0.0.0.0
+LINE_RECEIVER_PORT = 2023
+
+PICKLE_RECEIVER_INTERFACE = 0.0.0.0
+PICKLE_RECEIVER_PORT = 2024
+
+# This is a list of carbon daemons we will send any relayed or
+# generated metrics to. The default provided would send to a single
+# carbon-cache instance on the default port. However if you
+# use multiple carbon-cache instances then it would look like this:
+#
+# DESTINATIONS = 127.0.0.1:2004:a, 127.0.0.1:2104:b
+#
+# The format is comma-delimited IP:PORT:INSTANCE where the :INSTANCE part is
+# optional and refers to the "None" instance if omitted.
+#
+# Note that if the destinations are all carbon-caches then this should
+# exactly match the webapp's CARBONLINK_HOSTS setting in terms of
+# instances listed (order matters!).
+DESTINATIONS = 127.0.0.1:2004
+
+# If you want to add redundancy to your data by replicating every
+# datapoint to more than one machine, increase this.
+REPLICATION_FACTOR = 1
+
+# This is the maximum number of datapoints that can be queued up
+# for a single destination. Once this limit is hit, we will
+# stop accepting new data if USE_FLOW_CONTROL is True, otherwise
+# we will drop any subsequently received datapoints.
+MAX_QUEUE_SIZE = 10000
+
+# Set this to False to drop datapoints when any send queue (sending datapoints
+# to a downstream carbon daemon) hits MAX_QUEUE_SIZE. If this is True (the
+# default) then sockets over which metrics are received will temporarily stop accepting
+# data until the send queues fall below 80% MAX_QUEUE_SIZE.
+USE_FLOW_CONTROL = True
+
+# This defines the maximum "message size" between carbon daemons.
+# You shouldn't need to tune this unless you really know what you're doing.
+MAX_DATAPOINTS_PER_MESSAGE = 500
+
+# This defines how many datapoints the aggregator remembers for
+# each metric. Aggregation only happens for datapoints that fall in
+# the past MAX_AGGREGATION_INTERVALS * intervalSize seconds.
+MAX_AGGREGATION_INTERVALS = 5
+
+# Set this to True to enable whitelisting and blacklisting of metrics in
+# CONF_DIR/whitelist and CONF_DIR/blacklist. If the whitelist is missing or
+# empty, all metrics will pass through
+# USE_WHITELIST = False
+
+# By default, carbon itself will log statistics (such as a count,
+# metricsReceived) with the top level prefix of 'carbon' at an interval of 60
+# seconds. Set CARBON_METRIC_INTERVAL to 0 to disable instrumentation
+# CARBON_METRIC_PREFIX = carbon
+# CARBON_METRIC_INTERVAL = 60

--- a/salt/files/opt/graphite/conf/graph-templates.conf
+++ b/salt/files/opt/graphite/conf/graph-templates.conf
@@ -1,0 +1,38 @@
+[default]
+background = black
+foreground = white
+majorLine = white
+minorLine = grey
+lineColors = blue,green,red,purple,brown,yellow,aqua,grey,magenta,pink,gold,rose
+fontName = Sans
+fontSize = 10
+fontBold = False
+fontItalic = False
+
+[noc]
+background = black
+foreground = white
+majorLine = white
+minorLine = grey
+lineColors = blue,green,red,yellow,purple,brown,aqua,grey,magenta,pink,gold,rose
+fontName = Sans
+fontSize = 10
+fontBold = False
+fontItalic = False
+
+[plain]
+background = white
+foreground = black
+minorLine = grey
+majorLine = rose
+
+[summary]
+background = black
+lineColors = #6666ff, #66ff66, #ff6666
+
+[alphas]
+background = white
+foreground = black
+majorLine = grey
+minorLine = rose
+lineColors = 00ff00aa,ff000077,00337799

--- a/salt/files/opt/graphite/conf/relay-rules.conf.jinja
+++ b/salt/files/opt/graphite/conf/relay-rules.conf.jinja
@@ -1,0 +1,21 @@
+# Relay destination rules for carbon-relay. Entries are scanned in order,
+# and the first pattern a metric matches will cause processing to cease after sending
+# unless `continue` is set to true
+#
+#  [name]
+#  pattern = <regex>
+#  destinations = <list of destination addresses>
+#  continue = <boolean>  # default: False
+#
+#  name: Arbitrary unique name to identify the rule
+#  pattern: Regex pattern to match against the metric name
+#  destinations: Comma-separated list of destinations.
+#    ex: 127.0.0.1, 10.1.2.3:2004, 10.1.2.4:2004:a, myserver.mydomain.com
+#  continue: Continue processing rules if this rule matches (default: False)
+
+# You must have exactly one section with 'default = true'
+# Note that all destinations listed must also exist in carbon.conf
+# in the DESTINATIONS setting in the [relay] section
+[default]
+default = true
+destinations = 127.0.0.1:2013

--- a/salt/files/opt/graphite/conf/storage-schemas.conf
+++ b/salt/files/opt/graphite/conf/storage-schemas.conf
@@ -1,0 +1,53 @@
+# Schema definitions for Whisper files. Entries are scanned in order,
+# and first match wins. This file is scanned for changes every 60 seconds.
+#
+#  [name]
+#  pattern = regex
+#  retentions = timePerPoint:timeToStore, timePerPoint:timeToStore, ...
+
+# Carbon's internal metrics. This entry should match what is specified in
+# CARBON_METRIC_PREFIX and CARBON_METRIC_INTERVAL settings
+
+[carbon]
+pattern = ^carbon\.
+retentions = 60:90d
+
+[abacus]
+pattern = ^stats\.abacus\.healthchecks
+retentions = 1m:90d,5m:1y,10m:5y
+
+#our statsd retention is 10 second resolution for 6 hours, 1 minute for 30 days, 5 minute for, 1 year, and 10 minutes for 5 years.
+[stats]
+priority = 110
+pattern = ^stats\..*
+retentions = 10:2160,1m:30d,5m:1y,10m:5y
+
+#our stats_counts (i.e. total requests) 1 minute for 30 days, 5 minute for, 1 year, and 10 minutes for 5 years.
+[stats_counts]
+priority = 110
+pattern = ^stats\_counts\..*
+retentions = 1m:30d,5m:1y,10m:5y
+
+#recon stats
+[recon]
+pattern = ^swift\.recon\..*
+retentions = 5m:90d,30m:1y,1h:5y
+
+#billing stats
+[billing]
+pattern = ^swift\.billing\..*
+retentions = 1h:5y
+
+#default swift match
+[swift]
+pattern = ^swift\..*
+retentions = 1m:30d,5m:1y,1h:5y
+
+#diamond stats
+[diamond]
+pattern = ^servers\..*
+retentions = 5m:90d,30m:1y,1h:2y
+
+[default_1min_for_1day]
+pattern = .*
+retentions = 60s:1d

--- a/salt/files/opt/graphite/webapp/graphite/local_settings.py.jinja
+++ b/salt/files/opt/graphite/webapp/graphite/local_settings.py.jinja
@@ -1,0 +1,220 @@
+## Graphite local_settings.py
+# Edit this file to customize the default Graphite webapp settings
+#
+# Additional customizations to Django settings can be added to this file as well
+
+#####################################
+# General Configuration #
+#####################################
+# Set this to a long, random unique string to use as a secret key for this
+# install. This key is used for salting of hashes used in auth tokens,
+# CRSF middleware, cookie storage, etc. This should be set identically among
+# instances if used behind a load balancer.
+SECRET_KEY = '{{ pillar['graphite_django_secret_key'] }}'
+
+# In Django 1.5+ set this to the list of hosts your graphite instances is
+# accessible as. See:
+# https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-ALLOWED_HOSTS
+#ALLOWED_HOSTS = [ '*' ]
+
+# Set your local timezone (Django's default is America/Chicago)
+# If your graphs appear to be offset by a couple hours then this probably
+# needs to be explicitly set to your local timezone.
+TIME_ZONE = 'Etc/UTC'
+
+# Override this to provide documentation specific to your Graphite deployment
+#DOCUMENTATION_URL = "http://graphite.readthedocs.org/"
+
+# Logging
+#LOG_RENDERING_PERFORMANCE = True
+#LOG_CACHE_PERFORMANCE = True
+#LOG_METRIC_ACCESS = True
+
+# Enable full debug page display on exceptions (Internal Server Error pages)
+#DEBUG = True
+
+# If using RRD files and rrdcached, set to the address or socket of the daemon
+#FLUSHRRDCACHED = 'unix:/var/run/rrdcached.sock'
+
+# This lists the memcached servers that will be used by this webapp.
+# If you have a cluster of webapps you should ensure all of them
+# have the *exact* same value for this setting. That will maximize cache
+# efficiency. Setting MEMCACHE_HOSTS to be empty will turn off use of
+# memcached entirely.
+#
+# You should not use the loopback address (127.0.0.1) here if using clustering
+# as every webapp in the cluster should use the exact same values to prevent
+# unneeded cache misses. Set to [] to disable caching of images and fetched data
+#MEMCACHE_HOSTS = ['10.10.10.10:11211', '10.10.10.11:11211', '10.10.10.12:11211']
+#DEFAULT_CACHE_DURATION = 60 # Cache images and data for 1 minute
+
+
+#####################################
+# Filesystem Paths #
+#####################################
+# Change only GRAPHITE_ROOT if your install is merely shifted from /opt/graphite
+# to somewhere else
+#GRAPHITE_ROOT = '/opt/graphite'
+
+# Most installs done outside of a separate tree such as /opt/graphite will only
+# need to change these three settings. Note that the default settings for each
+# of these is relative to GRAPHITE_ROOT
+#CONF_DIR = '/opt/graphite/conf'
+#STORAGE_DIR = '/opt/graphite/storage'
+#CONTENT_DIR = '/opt/graphite/webapp/content'
+
+# To further or fully customize the paths, modify the following. Note that the
+# default settings for each of these are relative to CONF_DIR and STORAGE_DIR
+#
+## Webapp config files
+#DASHBOARD_CONF = '/opt/graphite/conf/dashboard.conf'
+#GRAPHTEMPLATES_CONF = '/opt/graphite/conf/graphTemplates.conf'
+
+## Data directories
+# NOTE: If any directory is unreadable in DATA_DIRS it will break metric browsing
+#WHISPER_DIR = '/opt/graphite/storage/whisper'
+#RRD_DIR = '/opt/graphite/storage/rrd'
+#DATA_DIRS = [WHISPER_DIR, RRD_DIR] # Default: set from the above variables
+#LOG_DIR = '/opt/graphite/storage/log/webapp'
+#INDEX_FILE = '/opt/graphite/storage/index'  # Search index file
+
+
+#####################################
+# Email Configuration #
+#####################################
+# This is used for emailing rendered Graphs
+# Default backend is SMTP
+#EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+#EMAIL_HOST = 'localhost'
+#EMAIL_PORT = 25
+#EMAIL_HOST_USER = ''
+#EMAIL_HOST_PASSWORD = ''
+#EMAIL_USE_TLS = False
+# To drop emails on the floor, enable the Dummy backend:
+EMAIL_BACKEND = 'django.core.mail.backends.dummy.EmailBackend'
+
+
+#####################################
+# Authentication Configuration #
+#####################################
+## LDAP / ActiveDirectory authentication setup
+#USE_LDAP_AUTH = True
+#LDAP_SERVER = "ldap.mycompany.com"
+#LDAP_PORT = 389
+#   OR
+#LDAP_URI = "ldaps://ldap.mycompany.com:636"
+#LDAP_SEARCH_BASE = "OU=users,DC=mycompany,DC=com"
+#LDAP_BASE_USER = "CN=some_readonly_account,DC=mycompany,DC=com"
+#LDAP_BASE_PASS = "readonly_account_password"
+#LDAP_USER_QUERY = "(username=%s)"  #For Active Directory use "(sAMAccountName=%s)"
+#
+# If you want to further customize the ldap connection options you should
+# directly use ldap.set_option to set the ldap module's global options.
+# For example:
+#
+#import ldap
+#ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_ALLOW)
+#ldap.set_option(ldap.OPT_X_TLS_CACERTDIR, "/etc/ssl/ca")
+#ldap.set_option(ldap.OPT_X_TLS_CERTFILE, "/etc/ssl/mycert.pem")
+#ldap.set_option(ldap.OPT_X_TLS_KEYFILE, "/etc/ssl/mykey.pem")
+# See http://www.python-ldap.org/ for further details on these options.
+
+## REMOTE_USER authentication. See: https://docs.djangoproject.com/en/dev/howto/auth-remote-user/
+#USE_REMOTE_USER_AUTHENTICATION = True
+
+# Override the URL for the login link (e.g. for django_openid_auth)
+#LOGIN_URL = '/account/login'
+
+
+##########################
+# Database Configuration #
+##########################
+# By default sqlite is used. If you cluster multiple webapps you will need
+# to setup an external database (such as MySQL) and configure all of the webapp
+# instances to use the same database. Note that this database is only used to store
+# Django models such as saved graphs, dashboards, user preferences, etc.
+# Metric data is not stored here.
+#
+# DO NOT FORGET TO RUN 'manage.py syncdb' AFTER SETTING UP A NEW DATABASE
+#
+# The following built-in database engines are available:
+#  django.db.backends.postgresql          # Removed in Django 1.4
+#  django.db.backends.postgresql_psycopg2
+#  django.db.backends.mysql
+#  django.db.backends.sqlite3
+#  django.db.backends.oracle
+#
+# The default is 'django.db.backends.sqlite3' with file 'graphite.db'
+# located in STORAGE_DIR
+#
+DATABASES = {
+    'default': {
+        'NAME': '/opt/graphite/storage/graphite.db',
+        'ENGINE': 'django.db.backends.sqlite3',
+        'USER': '',
+        'PASSWORD': '',
+        'HOST': '',
+        'PORT': ''
+    }
+}
+
+
+
+#########################
+# Cluster Configuration #
+#########################
+# (To avoid excessive DNS lookups you want to stick to using IP addresses only in this entire section)
+#
+# This should list the IP address (and optionally port) of the webapp on each
+# remote server in the cluster. These servers must each have local access to
+# metric data. Note that the first server to return a match for a query will be
+# used.
+#CLUSTER_SERVERS = ["10.0.2.2:80", "10.0.2.3:80"]
+
+## These are timeout values (in seconds) for requests to remote webapps
+#REMOTE_STORE_FETCH_TIMEOUT = 6   # Timeout to fetch series data
+#REMOTE_STORE_FIND_TIMEOUT = 2.5  # Timeout for metric find requests
+#REMOTE_STORE_RETRY_DELAY = 60    # Time before retrying a failed remote webapp
+#REMOTE_STORE_USE_POST = False    # Use POST instead of GET for remote requests
+#REMOTE_FIND_CACHE_DURATION = 300 # Time to cache remote metric find results
+
+## Prefetch cache
+# set to True to fetch all metrics using a single http request per remote server
+# instead of one http request per target, per remote server.
+# Especially useful when generating graphs with more than 4-5 targets or if
+# there's significant latency between this server and the backends. (>20ms)
+#REMOTE_PREFETCH_DATA = False
+
+# During a rebalance of a consistent hash cluster, after a partition event on a replication > 1 cluster,
+# or in other cases we might receive multiple TimeSeries data for a metric key.  Merge them together rather
+# that choosing the "most complete" one (pre-0.9.14 behaviour).
+#REMOTE_STORE_MERGE_RESULTS = True
+
+## Remote rendering settings
+# Set to True to enable rendering of Graphs on a remote webapp
+#REMOTE_RENDERING = True
+# List of IP (and optionally port) of the webapp on each remote server that
+# will be used for rendering. Note that each rendering host should have local
+# access to metric data or should have CLUSTER_SERVERS configured
+#RENDERING_HOSTS = []
+#REMOTE_RENDER_CONNECT_TIMEOUT = 1.0
+
+# If you are running multiple carbon-caches on this machine (typically behind a relay using
+# consistent hashing), you'll need to list the ip address, cache query port, and instance name of each carbon-cache
+# instance on the local machine (NOT every carbon-cache in the entire cluster). The default cache query port is 7002
+# and a common scheme is to use 7102 for instance b, 7202 for instance c, etc.
+#
+# You *should* use 127.0.0.1 here in most cases
+#CARBONLINK_HOSTS = ["127.0.0.1:7002:a", "127.0.0.1:7102:b", "127.0.0.1:7202:c"]
+#CARBONLINK_TIMEOUT = 1.0
+# Using 'query-bulk' queries for carbon
+# It's more effective, but python-carbon 0.9.13 (or latest from 0.9.x branch) is required
+# See https://github.com/graphite-project/carbon/pull/132 for details
+#CARBONLINK_QUERY_BULK = False
+
+#####################################
+# Additional Django Settings #
+#####################################
+# Uncomment the following line for direct access to Django settings such as
+# MIDDLEWARE_CLASSES or APPS
+#from graphite.app_settings import *

--- a/salt/master/conf
+++ b/salt/master/conf
@@ -1,0 +1,11 @@
+auto_accept: True
+state_output: full
+state_verbose: true
+
+file_roots:
+  base:
+    - /srv/salt/files
+    - /srv/salt/states
+pillar_roots:
+  base:
+    - /srv/salt/pillar

--- a/salt/minion/conf
+++ b/salt/minion/conf
@@ -1,11 +1,12 @@
+mine_interval: 5
+state_output: full
+state_verbose: True
+recon_randomize: True
+
 include:
   - /etc/salt/grains
 
-file_client: local
-file_roots:
-  base:
-    - /vagrant/salt/files
-    - /vagrant/salt/states
-pillar_roots:
-  base:
-    - /vagrant/salt/pillar
+schedule:
+  sync:
+    function: saltutil.sync_all
+    seconds: 600

--- a/salt/minion/grains/admin
+++ b/salt/minion/grains/admin
@@ -1,0 +1,8 @@
+roles:
+  - admin
+  - swift
+  - saltmaster
+  - syslog
+  - statsd
+  - carbon
+  - graphite

--- a/salt/minion/grains/lb
+++ b/salt/minion/grains/lb
@@ -1,2 +1,3 @@
 roles:
   - swift
+  - haproxy

--- a/salt/minion/grains/proxy
+++ b/salt/minion/grains/proxy
@@ -1,0 +1,5 @@
+roles:
+  - swift
+  - swift-proxy
+  - memcached
+  - hourly_logs

--- a/salt/minion/grains/storage
+++ b/salt/minion/grains/storage
@@ -1,0 +1,6 @@
+roles:
+  - swift
+  - swift-object
+  - swift-container
+  - swift-account
+  - hourly_logs

--- a/salt/pillar/globals.sls
+++ b/salt/pillar/globals.sls
@@ -1,0 +1,4 @@
+mine_functions:
+  network.ip_addrs: [eth1]
+
+syslog_log_fifo_size: 4096

--- a/salt/pillar/graphite.sls
+++ b/salt/pillar/graphite.sls
@@ -1,0 +1,1 @@
+graphite_django_secret_key: "change_this"

--- a/salt/pillar/haproxy.sls
+++ b/salt/pillar/haproxy.sls
@@ -1,0 +1,4 @@
+haproxy_global_maxconn: 30000
+haproxy_nbproc: 1
+haproxy_listen: "0.0.0.0:80"
+haproxy_frontend_maxconn: 5000

--- a/salt/pillar/memcached.sls
+++ b/salt/pillar/memcached.sls
@@ -1,0 +1,3 @@
+memcache:
+  simultaneous_conn: 10248
+  memory: 2048

--- a/salt/pillar/swift.sls
+++ b/salt/pillar/swift.sls
@@ -1,2 +1,39 @@
 swift_hash_path_suffix: change_this
 swift_hash_path_prefix: and_change_this_too
+
+swift_install_type: git
+swift_object_server: python-swift
+
+swift_git_install_branch: master
+swift_pkg_install_type: repo
+swift_pkg_repo_url: false
+swift_pkg_download_url: false
+
+swift:
+  proxy:
+    pipeline: informant catch_errors gatekeeper healthcheck proxy-logging cache bulk tempurl formpost swauth container-quotas ratelimit staticweb slo dlo proxy-logging proxy-server
+    workers: 8
+    trans_id_suffix: vagrant
+    recoverable_node_timeout: 3
+    node_timeout: 60
+    conn_timeout: 3.5
+    max_containers_whitelist: .expiring_objects
+    account_whitelist: TEST
+    allow_account_management: false
+    account_autocreate: true
+    strict_cors_mode: true
+    request_node_count: 2 * replicas
+    log_handoffs: true
+    log_max_line_length: 8192
+    max_containers_per_account: 50000
+    account_ratelimit: 200000.0
+    container_ratelimit: 100
+    memcache_serialization_support: 2
+    bulk_yield_frequency: 10
+    tempurl_methods: GET HEAD PUT DELETE
+    swauth_default_swift_cluster: "???"
+    swauth_super_admin_key: change_me
+    swauth_reseller_prefix: SWAUTH
+    informant_statsd_sample_rate: 0.25
+    informant_combined_events: yes
+    healthcheck_disable_path: /etc/swift/proxy_disabled

--- a/salt/pillar/swift.sls
+++ b/salt/pillar/swift.sls
@@ -1,0 +1,2 @@
+swift_hash_path_suffix: change_this
+swift_hash_path_prefix: and_change_this_too

--- a/salt/pillar/syslog.sls
+++ b/salt/pillar/syslog.sls
@@ -1,0 +1,1 @@
+syslog_log_fifo_size: 16000000

--- a/salt/pillar/top.sls
+++ b/salt/pillar/top.sls
@@ -1,0 +1,23 @@
+base:
+  '*':
+    - globals
+
+  'roles:graphite':
+    - match: grain
+    - graphite
+
+  'roles:swift':
+    - match: grain
+    - swift
+
+  'roles:memcached':
+    - match: grain
+    - memcached
+
+  'roles:haproxy':
+    - match: grain
+    - haproxy
+
+  'roles:syslog':
+    - match: grain
+    - syslog

--- a/salt/states/common/diamond.sls
+++ b/salt/states/common/diamond.sls
@@ -1,0 +1,66 @@
+include:
+  - common
+  - common.supervisor
+
+diamond:
+  pip.installed:
+    - name: diamond
+    - require:
+      - sls: common
+
+/etc/diamond:
+  file.directory:
+    - user: root
+    - group: root
+    - dir_mode: 775
+    - makedirs: True
+    - require:
+      - pip: diamond
+
+/etc/diamond/collectors:
+  file.directory:
+    - user: root
+    - group: root
+    - dir_mode: 775
+    - makedirs: True
+    - require:
+      - file: /etc/diamond
+
+/var/log/diamond:
+  file.directory:
+    - user: root
+    - group: root
+    - dir_mode: 775
+    - makedirs: True
+    - require:
+      - file: /etc/diamond
+
+/etc/diamond/diamond.conf:
+  file.managed:
+    - source: salt://etc/diamond/diamond.conf.jinja
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: 644
+    - require:
+      - file: /etc/diamond
+
+/etc/supervisor/conf.d/diamond.conf:
+  file.managed:
+    - source: salt://etc/supervisor/conf.d/conf.jinja
+    - template: jinja
+    - context:
+      processname: diamond
+      command: /usr/local/bin/diamond -f -c /etc/diamond/diamond.conf -u root -g root --skip-fork --log-stdout
+      run_as: root
+      autostart: true
+      autorestart: true
+      directory: /
+    - require:
+      - sls: common.supervisor
+      - file: /etc/diamond/diamond.conf
+      - pip: diamond
+  cmd.wait:
+    - name: supervisorctl reload
+    - watch:
+      - file: /etc/supervisor/conf.d/diamond.conf

--- a/salt/states/common/init.sls
+++ b/salt/states/common/init.sls
@@ -16,3 +16,6 @@ common_pkgs:
       - python-netifaces
       - sqlite3
       - traceroute
+      - python-dev
+      - build-essential
+      - libffi-dev

--- a/salt/states/common/init.sls
+++ b/salt/states/common/init.sls
@@ -21,6 +21,8 @@ common_pkgs:
       - build-essential
       - libffi-dev
       - liberasurecode-dev
+      - libssl-dev
+      - openssl
 
 common_pip:
   pip:
@@ -32,3 +34,6 @@ common_pip:
     - pkgs:
       - pip
       - gitdb
+      - pyopenssl
+      - ndg-httpsclient
+      - pyasn1

--- a/salt/states/common/init.sls
+++ b/salt/states/common/init.sls
@@ -6,6 +6,7 @@ common_pkgs:
       - patch
       - curl
       - debconf
+      - git
       - gcc
       - ethtool
       - strace
@@ -19,3 +20,15 @@ common_pkgs:
       - python-dev
       - build-essential
       - libffi-dev
+      - liberasurecode-dev
+
+common_pip:
+  pip:
+    - installed
+    - reload_modules: True
+    - upgrade: true
+    - require:
+      - pkg: common_pkgs
+    - pkgs:
+      - pip
+      - gitdb

--- a/salt/states/common/supervisor.sls
+++ b/salt/states/common/supervisor.sls
@@ -1,0 +1,12 @@
+supervisor:
+  pkg:
+    - installed
+    - hold: True
+
+supervisor_svc:
+  service:
+    - running
+    - name: supervisor
+    - enable: True
+    - require:
+      - pkg: supervisor

--- a/salt/states/common/syslog-ng.sls
+++ b/salt/states/common/syslog-ng.sls
@@ -1,0 +1,30 @@
+syslog-ng_pkgs:
+  pkg:
+    - installed
+    - skip_verify: True
+    - pkgs:
+      - syslog-ng-mod-json
+      - syslog-ng-mod-mongodb
+      - syslog-ng-mod-sql
+      - syslog-ng-core
+      - syslog-ng
+
+/etc/syslog-ng/syslog-ng.conf:
+  file.managed:
+    - source: salt://etc/syslog-ng/syslog-ng.conf.jinja
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: 644
+    - require:
+      - pkg: syslog-ng_pkgs
+
+syslog-ng_svc:
+  service:
+    - running
+    - name: syslog-ng
+    - enable: True
+    - require:
+      - pkg: syslog-ng_pkgs
+    - watch:
+      - file: /etc/syslog-ng/syslog-ng.conf

--- a/salt/states/graphite/init.sls
+++ b/salt/states/graphite/init.sls
@@ -2,101 +2,36 @@ include:
   - common
   - common.supervisor
 
-Django:
-  pip.installed:
-    - name: Django < 1.9
+graphite_python_pkgs:
+  pip:
+    - installed
     - require:
       - sls: common
+    - pkgs:
+      - Django < 1.9
+      - django-tagging
+      - pytz
+      - service_identity
+      - cairocffi
+      - gunicorn
+      - whisper
+      - carbon
+      - graphite-web
 
-django-tagging:
-  pip.installed:
-    - name: django-tagging
-    - require:
-      - pip: Django
-
-pytz:
-  pip.installed:
-    - name: pytz
-    - require:
-      - pip: django-tagging
-
-service_identity:
-  pip.installed:
-    - name: service_identity
-    - require:
-      - pip: pytz
-
-cairocffi:
-  pip.installed:
-    - name: cairocffi
-    - require:
-      - pip: service_identity
-
-gunicorn:
-  pip.installed:
-    - name: gunicorn
-    - require:
-      - pip: cairocffi
-
-whisper:
-  pip.installed:
-    - name: whisper
-    - require:
-      - pip: gunicorn
-
-carbon:
-  pip.installed:
-    - name: carbon
-    - require:
-      - pip: whisper
-
-graphite-web:
-  pip.installed:
-    - name: graphite-web
-    - require:
-      - pip: carbon
-
-/opt/graphite/conf/carbon.conf:
-  file.managed:
-    - source: salt://opt/graphite/conf/carbon.conf.jinja
+/opt/graphite/conf:
+  file.recurse:
+    - source: salt://opt/graphite/conf
     - user: root
     - group: root
-    - mode: 644
-    - require:
-      - pip: graphite-web
-
-/opt/graphite/conf/graph-templates.conf:
-  file.managed:
-    - source: salt://opt/graphite/conf/graph-templates.conf
-    - user: root
-    - group: root
-    - mode: 644
-    - require:
-      - pip: graphite-web
-
-/opt/graphite/conf/relay-rules.conf:
-  file.managed:
-    - source: salt://opt/graphite/conf/relay-rules.conf.jinja
-    - user: root
-    - group: root
-    - mode: 644
-    - require:
-      - pip: graphite-web
-
-/opt/graphite/conf/storage-schemas.conf:
-  file.managed:
-    - source: salt://opt/graphite/conf/storage-schemas.conf
-    - user: root
-    - group: root
-    - mode: 644
-    - require:
-      - pip: graphite-web
+    - file_mode: 644
+    - dir_mode: 755
+    - template: jinja
 
 /opt/graphite/webapp/graphite/graphite_wsgi.py:
   file.symlink:
     - target: /opt/graphite/conf/graphite.wsgi.example
     - require:
-      - pip: graphite-web
+      - pip: graphite_python_pkgs
 
 /opt/graphite/webapp/graphite/local_settings.py:
   file.managed:
@@ -106,7 +41,7 @@ graphite-web:
     - group: root
     - mode: 644
     - require:
-      - pip: graphite-web
+      - pip: graphite_python_pkgs
 
 initialize_sqlite:
   cmd:
@@ -150,7 +85,7 @@ initialize_sqlite:
       directory: /opt/graphite
     - require:
       - sls: common.supervisor
-      - file: /opt/graphite/conf/carbon.conf
+      - file: /opt/graphite/conf
   cmd.wait:
     - name: supervisorctl reload
     - watch:

--- a/salt/states/graphite/init.sls
+++ b/salt/states/graphite/init.sls
@@ -1,0 +1,157 @@
+include:
+  - common
+  - common.supervisor
+
+Django:
+  pip.installed:
+    - name: Django < 1.9
+    - require:
+      - sls: common
+
+django-tagging:
+  pip.installed:
+    - name: django-tagging
+    - require:
+      - pip: Django
+
+pytz:
+  pip.installed:
+    - name: pytz
+    - require:
+      - pip: django-tagging
+
+service_identity:
+  pip.installed:
+    - name: service_identity
+    - require:
+      - pip: pytz
+
+cairocffi:
+  pip.installed:
+    - name: cairocffi
+    - require:
+      - pip: service_identity
+
+gunicorn:
+  pip.installed:
+    - name: gunicorn
+    - require:
+      - pip: cairocffi
+
+whisper:
+  pip.installed:
+    - name: whisper
+    - require:
+      - pip: gunicorn
+
+carbon:
+  pip.installed:
+    - name: carbon
+    - require:
+      - pip: whisper
+
+graphite-web:
+  pip.installed:
+    - name: graphite-web
+    - require:
+      - pip: carbon
+
+/opt/graphite/conf/carbon.conf:
+  file.managed:
+    - source: salt://opt/graphite/conf/carbon.conf.jinja
+    - user: root
+    - group: root
+    - mode: 644
+    - require:
+      - pip: graphite-web
+
+/opt/graphite/conf/graph-templates.conf:
+  file.managed:
+    - source: salt://opt/graphite/conf/graph-templates.conf
+    - user: root
+    - group: root
+    - mode: 644
+    - require:
+      - pip: graphite-web
+
+/opt/graphite/conf/relay-rules.conf:
+  file.managed:
+    - source: salt://opt/graphite/conf/relay-rules.conf.jinja
+    - user: root
+    - group: root
+    - mode: 644
+    - require:
+      - pip: graphite-web
+
+/opt/graphite/conf/storage-schemas.conf:
+  file.managed:
+    - source: salt://opt/graphite/conf/storage-schemas.conf
+    - user: root
+    - group: root
+    - mode: 644
+    - require:
+      - pip: graphite-web
+
+/opt/graphite/webapp/graphite/graphite_wsgi.py:
+  file.symlink:
+    - target: /opt/graphite/conf/graphite.wsgi.example
+    - require:
+      - pip: graphite-web
+
+/opt/graphite/webapp/graphite/local_settings.py:
+  file.managed:
+    - source: salt://opt/graphite/webapp/graphite/local_settings.py.jinja
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: 644
+    - require:
+      - pip: graphite-web
+
+initialize_sqlite:
+  cmd:
+    - run
+    - name: python manage.py migrate --noinput
+    - cwd: /opt/graphite/webapp/graphite/
+    - require:
+      - file: /opt/graphite/webapp/graphite/local_settings.py
+    - unless:
+      - cmd: test -f /opt/graphite/storage/graphite.db
+
+/etc/supervisor/conf.d/graphiteweb.conf:
+  file.managed:
+    - source: salt://etc/supervisor/conf.d/conf.jinja
+    - template: jinja
+    - context:
+      processname: graphiteweb
+      command: gunicorn graphite_wsgi:application --bind 0.0.0.0:8888
+      run_as: root
+      autostart: true
+      autorestart: true
+      directory: /opt/graphite/webapp/graphite
+    - require:
+      - sls: common.supervisor
+      - cmd: initialize_sqlite
+  cmd.wait:
+    - name: supervisorctl reload
+    - watch:
+      - file: /etc/supervisor/conf.d/graphiteweb.conf
+
+/etc/supervisor/conf.d/carbon.conf:
+  file.managed:
+    - source: salt://etc/supervisor/conf.d/conf.jinja
+    - template: jinja
+    - context:
+      processname: carbon
+      command: python /opt/graphite/bin/carbon-cache.py --nodaemon --config=/opt/graphite/conf/storage-schemas.conf start
+      run_as: root
+      autostart: true
+      autorestart: true
+      directory: /opt/graphite
+    - require:
+      - sls: common.supervisor
+      - file: /opt/graphite/conf/carbon.conf
+  cmd.wait:
+    - name: supervisorctl reload
+    - watch:
+      - file: /etc/supervisor/conf.d/carbon.conf

--- a/salt/states/haproxy/files.sls
+++ b/salt/states/haproxy/files.sls
@@ -1,0 +1,20 @@
+haproxy_default:
+  file.replace:
+    - name: /etc/default/haproxy
+    - pattern: 'ENABLED=0'
+    - repl: 'ENABLED=1'
+    - require:
+      - sls: haproxy.packages
+      - pkg: haproxy_pkg
+
+haproxy_cfg:
+  file.managed:
+    - name: /etc/haproxy/haproxy.cfg
+    - source: salt://etc/haproxy/haproxy.cfg.jinja
+    - user: root
+    - group: root
+    - mode: 644
+    - template: jinja
+    - require:
+      - sls: haproxy.packages
+      - pkg: haproxy_pkg

--- a/salt/states/haproxy/init.sls
+++ b/salt/states/haproxy/init.sls
@@ -1,0 +1,13 @@
+include:
+  - haproxy.packages
+  - haproxy.files
+
+haproxy_svc:
+  service:
+    - running
+    - name: haproxy
+    - enable: True
+    - require:
+      - pkg: haproxy_pkg
+    - watch:
+      - file: /etc/haproxy/haproxy.cfg

--- a/salt/states/haproxy/packages.sls
+++ b/salt/states/haproxy/packages.sls
@@ -1,0 +1,20 @@
+haproxy_ppa:
+  pkgrepo.managed:
+    - name: deb http://ppa.launchpad.net/vbernat/haproxy-1.5/ubuntu {{ grains['oscodename'] }} main
+    - file: /etc/apt/sources.list.d/haproxy_ppa.list
+    - keyid: 505D97A41C61B9CD
+    - keyserver: hkp://keyserver.ubuntu.com:80
+    - refresh: True
+
+haproxy_pkg:
+  pkg:
+    - name: haproxy
+    - installed
+    - force_yes: True
+    - skip_verify: True
+
+haproxy:
+  apt:
+    - held
+    - require:
+      - pkg: haproxy_pkg

--- a/salt/states/statsd/init.sls
+++ b/salt/states/statsd/init.sls
@@ -1,0 +1,42 @@
+include:
+  - common.supervisor
+
+statsdaemon_server:
+  archive.extracted:
+    - name: /opt/
+    - source: https://github.com/bitly/statsdaemon/releases/download/v0.7.1/statsdaemon-0.7.1.linux-amd64.go1.4.2.tar.gz
+    - source_hash: md5=42d932699925b9256bf92753579ce69a
+    - archive_format: tar
+    - tar_options: z
+    - user: root
+    - group: root
+    - keep: false
+    - if_missing: /opt/statsdaemon-0.7.1.linux-amd64.go1.4.2/
+
+/usr/local/bin/statsdaemon:
+  file.symlink:
+    - target: /opt/statsdaemon-0.7.1.linux-amd64.go1.4.2/statsdaemon
+    - require:
+      - sls: common.supervisor
+      - archive: statsdaemon_server
+
+{% set server, statsd_addr = salt['mine.get']('roles:statsd', 'network.ip_addrs', expr_form='grain').items()[0] %}
+{% set server, graphite_addr = salt['mine.get']('roles:graphite', 'network.ip_addrs', expr_form='grain').items()[0] %}
+/etc/supervisor/conf.d/statsdaemon.conf:
+  file.managed:
+    - source: salt://etc/supervisor/conf.d/conf.jinja
+    - template: jinja
+    - context:
+      processname: statsdaemon
+      command: /usr/local/bin/statsdaemon -address="{{ statsd_addr[0] }}:8125" -percent-threshold=25 -percent-threshold=50 -percent-threshold=75 -percent-threshold=90 -percent-threshold=100 -prefix="stats." -receive-counter="wtf." -graphite="{{ graphite_addr[0] }}:2003"
+      run_as: root
+      autostart: true
+      autorestart: true
+      directory: /
+    - require:
+      - file: /usr/local/bin/statsdaemon
+      - sls: common.supervisor
+  cmd.wait:
+    - name: supervisorctl reload
+    - watch:
+      - file: /etc/supervisor/conf.d/statsdaemon.conf

--- a/salt/states/swift/base.sls
+++ b/salt/states/swift/base.sls
@@ -3,3 +3,61 @@ swift_deps_pkgs:
     - installed
     - pkgs:
       - xfsprogs
+
+swift:
+  group.present:
+    - gid: 2000
+    - system: true
+  user.present:
+    - gid_from_name: true
+    - remove_groups: false
+    - createhome: false
+    - system: true
+    - uid: 2000
+    - require:
+      - group: swift
+
+/etc/swift:
+  file.directory:
+    - user: swift
+    - group: swift
+    - dir_mode: 775
+    - makedirs: True
+    - require:
+      - user: swift
+
+/etc/swift/swift.conf:
+  file.managed:
+    - source: salt://etc/swift/swift.conf.jinja
+    - user: swift
+    - group: swift
+    - mode: 644
+    - template: jinja
+    - require:
+      - file: /etc/swift
+
+/etc/swift/memcache.conf:
+  file.managed:
+    - source: salt://etc/swift/memcache.conf.jinja
+    - user: swift
+    - group: swift
+    - mode: 644
+    - template: jinja
+    - require:
+      - file: /etc/swift
+
+/var/run/swift:
+  file.directory:
+    - user: root
+    - group: root
+    - dir_mode: 755
+    - makedirs: True
+
+/var/cache/swift:
+  file.directory:
+    - user: swift
+    - group: swift
+    - dir_mode: 755
+    - makedirs: True
+    - require:
+      - user: swift

--- a/salt/states/swift/git_install.sls
+++ b/salt/states/swift/git_install.sls
@@ -1,0 +1,32 @@
+include:
+  - common
+
+setuptools:
+  pip:
+    - name: setuptools >= 17.1
+    - installed
+    - force_reinstall: true
+    - require:
+      - sls: common
+
+swift_source:
+  git.latest:
+    - name: https://github.com/openstack/swift.git
+    {%- if pillar['swift_object_server'] == "hummingbird" %}
+    - rev: feature/hummingbird
+    {%- else %}
+    - rev: master
+    {% endif %}
+    - target: /srv/swift
+    - force: true
+    - force_checkout: true
+
+swift_source_install:
+  pip:
+    - name: /srv/swift/
+    - installed
+    - upgrade: true
+    - force_reinstall: true
+    - require:
+      - pip: setuptools
+      - git: swift_source

--- a/salt/states/swift/init.sls
+++ b/salt/states/swift/init.sls
@@ -1,2 +1,5 @@
 include:
   - swift.base
+  {% if pillar['swift_install_type'] == "git" %}
+  - swift.git_install
+  {% endif %}

--- a/salt/states/swift/memcached.sls
+++ b/salt/states/swift/memcached.sls
@@ -1,0 +1,23 @@
+memcached:
+  pkg:
+    - installed
+    - skip_verify: True
+
+
+/etc/memcached.conf:
+  file.managed:
+    - source: salt://etc/memcached.conf.jinja
+    - user: root
+    - group: root
+    - mode: 644
+    - template: jinja
+    - require:
+      - pkg: memcached
+  service:
+    - running
+    - name: memcached
+    - enable: True
+    - require:
+      - pkg: memcached
+    - watch:
+      - file: /etc/memcached.conf

--- a/salt/states/swift/memcached.sls
+++ b/salt/states/swift/memcached.sls
@@ -3,7 +3,6 @@ memcached:
     - installed
     - skip_verify: True
 
-
 /etc/memcached.conf:
   file.managed:
     - source: salt://etc/memcached.conf.jinja

--- a/salt/states/swift/proxy.sls
+++ b/salt/states/swift/proxy.sls
@@ -1,0 +1,19 @@
+include:
+  - swift.base
+
+/etc/swift/mime.types:
+  file.managed:
+    - source: salt://etc/swift/proxy.d/mime.types
+    - user: swift
+    - group: swift
+    - mode: 644
+    - require:
+      - user: swift
+
+/etc/swift/proxy-server.conf:
+  file.managed:
+    - source: salt://etc/swift/proxy.d/proxy-server.conf.jinja
+    - user: swift
+    - group: swift
+    - mode: 644
+    - template: jinja

--- a/salt/states/top.sls
+++ b/salt/states/top.sls
@@ -1,7 +1,25 @@
 base:
   '*':
     - common
+    - common.syslog-ng
+    - common.diamond
 
   'roles:swift':
     - match: grain
     - swift
+
+  'roles:haproxy':
+    - match: grain
+    - haproxy
+
+  'roles:graphite':
+    - match: grain
+    - graphite
+
+  'roles:statsd':
+    - match: grain
+    - statsd
+
+  'roles:swift-proxy':
+    - match: grain
+    - swift.memcached

--- a/salt/states/top.sls
+++ b/salt/states/top.sls
@@ -23,3 +23,4 @@ base:
   'roles:swift-proxy':
     - match: grain
     - swift.memcached
+    - swift.proxy


### PR DESCRIPTION
so this does a few things, sorry its a big change but its basically "logging and metrics"

- moves away from masterless salt, adds an admin server to be salt master
- configures graphite, carbon, statsd services, starts them running under supervisord
- enabled diamond metric collector on all nodes
- configures a centralised syslog host (admin1) for all swift and haproxy logs
- configures haproxy backend with any swift-proxy servers
- configures swift memcache conf with any memcache servers
- probably some other stuff